### PR TITLE
avoid null bytes in event name

### DIFF
--- a/inotify-asio/inotify.hpp
+++ b/inotify-asio/inotify.hpp
@@ -277,6 +277,26 @@ public:
                 initiation, token, std::ref(desc_), std::ref(buffer_));
     }
 
+    void cancel()
+    {
+        desc_.cancel();
+    }
+
+    void close()
+    {
+        desc_.close();
+    }
+
+    void cancel(boost::system::error_code& ec)
+    {
+        desc_.cancel(ec);
+    }
+
+    void close(boost::system::error_code& ec)
+    {
+        desc_.close(ec);
+    }
+
 private:
     static event extract_event(boost::beast::flat_buffer &buffer)
     {

--- a/inotify-asio/inotify.hpp
+++ b/inotify-asio/inotify.hpp
@@ -10,6 +10,7 @@
 
 #include <string>
 #include <string_view>
+#include <cstring>
 
 #include <sys/inotify.h>
 
@@ -70,7 +71,7 @@ public:
         : wd_(ev->wd),
           mask_(ev->mask),
           cookie_(ev->cookie),
-          name_(ev->name, ev->len ? ev->len - 1 : 0)
+          name_(ev->name, ev->len ? strnlen(ev->name, ev->len) : 0)
     {}
 
     int wd() const


### PR DESCRIPTION
previously the event name would include the null terminator and any padding bytes